### PR TITLE
fix(35): update DB Fragmentation and Message Delivery Rate alerts

### DIFF
--- a/grafana/provisioning/alerting/cht.yml
+++ b/grafana/provisioning/alerting/cht.yml
@@ -540,22 +540,43 @@ groups:
         isPaused: false
       - uid: nBTZsCY4k
         title: Client Feedback/Error Rate
-        condition: C
+        condition: B
         data:
-          - refId: A
+          - refId: feedback_rate
             relativeTimeRange:
               from: 600
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
               editorMode: code
+              exemplar: false
               expr: rate(cht_feedback_total[24h]) * 60 * 60 * 24
               hide: false
+              instant: true
               intervalMs: 1000
               legendFormat: __auto
               maxDataPoints: 43200
-              range: true
-              refId: A
+              range: false
+              refId: feedback_rate
+          - refId: threshold
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              datasource:
+                type: prometheus
+                uid: PBFA97CFB590B2093
+              editorMode: code
+              exemplar: false
+              expr: cht_connected_users_count / 10
+              hide: false
+              instant: true
+              intervalMs: 1000
+              legendFormat: __auto
+              maxDataPoints: 43200
+              range: false
+              refId: threshold
           - refId: B
             relativeTimeRange:
               from: 600
@@ -564,58 +585,27 @@ groups:
             model:
               conditions:
                 - evaluator:
-                    params: []
+                    params:
+                      - 0
+                      - 0
                     type: gt
                   operator:
                     type: and
                   query:
-                    params:
-                      - B
+                    params: []
                   reducer:
                     params: []
-                    type: last
+                    type: avg
                   type: query
               datasource:
+                name: Expression
                 type: __expr__
                 uid: __expr__
-              expression: A
-              hide: false
+              expression: ${feedback_rate} > ${threshold}
               intervalMs: 1000
               maxDataPoints: 43200
-              reducer: last
               refId: B
-              settings:
-                mode: ""
-              type: reduce
-          - refId: C
-            relativeTimeRange:
-              from: 600
-              to: 0
-            datasourceUid: __expr__
-            model:
-              conditions:
-                - evaluator:
-                    params:
-                      - 4
-                    type: gt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                      - C
-                  reducer:
-                    params: []
-                    type: last
-                  type: query
-              datasource:
-                type: __expr__
-                uid: __expr__
-              expression: B
-              hide: false
-              intervalMs: 1000
-              maxDataPoints: 43200
-              refId: C
-              type: threshold
+              type: math
         dashboardUid: oa2OfL-Vk
         panelId: 14
         noDataState: NoData
@@ -716,52 +706,44 @@ groups:
         isPaused: false
       - uid: 0R-OsCYVz
         title: Message Delivery Rate
-        condition: C
+        condition: alert
         data:
-          - refId: A
+          - refId: delivered_rate
             relativeTimeRange:
               from: 600
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
               editorMode: code
-              expr: rate(cht_messaging_outgoing_total{status="delivered"}[24h]) / on (instance) (rate(cht_messaging_outgoing_total{status="delivered"}[24h]) + on (instance) rate(cht_messaging_outgoing_total{status="failed"}[24h]))
+              exemplar: false
+              expr: rate(cht_messaging_outgoing_total{status="delivered"}[24h])
               hide: false
+              instant: true
               intervalMs: 1000
               legendFormat: __auto
               maxDataPoints: 43200
-              range: true
-              refId: A
-          - refId: C
+              range: false
+              refId: delivered_rate
+          - refId: total_rate
             relativeTimeRange:
               from: 600
               to: 0
-            datasourceUid: __expr__
+            datasourceUid: PBFA97CFB590B2093
             model:
-              conditions:
-                - evaluator:
-                    params:
-                      - 0.9
-                    type: lt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                      - C
-                  reducer:
-                    params: []
-                    type: last
-                  type: query
               datasource:
-                type: __expr__
-                uid: __expr__
-              expression: E
+                type: prometheus
+                uid: PBFA97CFB590B2093
+              editorMode: code
+              exemplar: false
+              expr: rate(cht_messaging_outgoing_total{status="delivered"}[24h]) + on(instance) rate(cht_messaging_outgoing_total{status="failed"}[24h])
               hide: false
+              instant: true
               intervalMs: 1000
+              legendFormat: __auto
               maxDataPoints: 43200
-              refId: C
-              type: threshold
-          - refId: E
+              range: false
+              refId: total_rate
+          - refId: delivered_pct
             relativeTimeRange:
               from: 600
               to: 0
@@ -785,15 +767,38 @@ groups:
                 name: Expression
                 type: __expr__
                 uid: __expr__
-              expression: A
+              expression: ${delivered_rate}/${total_rate}
               intervalMs: 1000
               maxDataPoints: 43200
-              reducer: last
-              refId: E
-              settings:
-                mode: replaceNN
-                replaceWithValue: 1
-              type: reduce
+              refId: delivered_pct
+              type: math
+          - refId: alert
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: []
+                  reducer:
+                    params: []
+                    type: avg
+                  type: query
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: '!is_nan(${delivered_pct}) && ${delivered_pct} < 0.9'
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: alert
+              type: math
         dashboardUid: oa2OfL-Vk
         panelId: 27
         noDataState: NoData

--- a/grafana/provisioning/alerting/cht.yml
+++ b/grafana/provisioning/alerting/cht.yml
@@ -725,59 +725,13 @@ groups:
             datasourceUid: PBFA97CFB590B2093
             model:
               editorMode: code
-              expr: rate(cht_messaging_outgoing_total{status="delivered"}[24h])
+              expr: rate(cht_messaging_outgoing_total{status="delivered"}[24h]) / on (instance) (rate(cht_messaging_outgoing_total{status="delivered"}[24h]) + on (instance) rate(cht_messaging_outgoing_total{status="failed"}[24h]))
               hide: false
               intervalMs: 1000
               legendFormat: __auto
               maxDataPoints: 43200
               range: true
               refId: A
-          - refId: D
-            relativeTimeRange:
-              from: 600
-              to: 0
-            datasourceUid: PBFA97CFB590B2093
-            model:
-              datasource:
-                type: prometheus
-                uid: PBFA97CFB590B2093
-              editorMode: code
-              expr: rate(cht_messaging_outgoing_total{status="failed"}[24h])
-              hide: false
-              intervalMs: 1000
-              legendFormat: __auto
-              maxDataPoints: 43200
-              range: true
-              refId: D
-          - refId: B
-            relativeTimeRange:
-              from: 600
-              to: 0
-            datasourceUid: __expr__
-            model:
-              conditions:
-                - evaluator:
-                    params:
-                      - 0
-                      - 0
-                    type: gt
-                  operator:
-                    type: and
-                  query:
-                    params: []
-                  reducer:
-                    params: []
-                    type: avg
-                  type: query
-              datasource:
-                name: Expression
-                type: __expr__
-                uid: __expr__
-              expression: $A/($A + $D)
-              intervalMs: 1000
-              maxDataPoints: 43200
-              refId: B
-              type: math
           - refId: C
             relativeTimeRange:
               from: 600
@@ -808,6 +762,9 @@ groups:
               refId: C
               type: threshold
           - refId: E
+            relativeTimeRange:
+              from: 600
+              to: 0
             datasourceUid: __expr__
             model:
               conditions:
@@ -828,11 +785,14 @@ groups:
                 name: Expression
                 type: __expr__
                 uid: __expr__
-              expression: B
+              expression: A
               intervalMs: 1000
               maxDataPoints: 43200
               reducer: last
               refId: E
+              settings:
+                mode: replaceNN
+                replaceWithValue: 1
               type: reduce
         dashboardUid: oa2OfL-Vk
         panelId: 27

--- a/grafana/provisioning/alerting/cht.yml
+++ b/grafana/provisioning/alerting/cht.yml
@@ -16,7 +16,7 @@ groups:
             datasourceUid: PBFA97CFB590B2093
             model:
               editorMode: code
-              expr: cht_couchdb_fragmentation
+              expr: cht_couchdb_fragmentation and on (db) (cht_couchdb_doc_total > 1000)
               hide: false
               intervalMs: 1000
               legendFormat: __auto

--- a/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
@@ -106,7 +106,7 @@
         "content": "# CHT Admin Dashboard\n\nSee the [CHT documentation](https://docs.communityhealthtoolkit.org/apps/guides/hosting/monitoring/) for more information about monitoring and alerting!",
         "mode": "markdown"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "type": "text"
     },
     {
@@ -169,6 +169,7 @@
         }
       ],
       "options": {
+        "cellHeight": "sm",
         "footer": {
           "countRows": false,
           "fields": "",
@@ -180,7 +181,7 @@
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -373,7 +374,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -458,7 +459,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -557,7 +558,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -600,20 +601,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
                 "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 5
+                "value": null
               }
             ]
           },
@@ -649,7 +638,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -661,10 +650,40 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "cht_connected_users_count{instance=~\"$cht_instance\"} / 10",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "threshold",
+          "range": false,
+          "refId": "B"
         }
       ],
       "title": "DB Conflicts Rate",
       "transformations": [
+        {
+          "id": "configFromData",
+          "options": {
+            "applyTo": {
+              "id": "byType",
+              "options": "number"
+            },
+            "configRefId": "B",
+            "mappings": [
+              {
+                "fieldName": "threshold",
+                "handlerKey": "threshold1"
+              }
+            ]
+          }
+        },
         {
           "id": "renameByRegex",
           "options": {
@@ -740,9 +759,10 @@
           "fields": "",
           "values": false
         },
-        "showUnfilled": true
+        "showUnfilled": true,
+        "valueMode": "color"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -847,7 +867,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -947,7 +967,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -1038,7 +1058,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -1129,7 +1149,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -1204,20 +1224,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
                 "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 5
+                "value": null
               }
             ]
           },
@@ -1253,7 +1261,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -1265,10 +1273,34 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "cht_connected_users_count{instance=~\"$cht_instance\"} / 10",
+          "hide": false,
+          "legendFormat": "threshold",
+          "range": true,
+          "refId": "B"
         }
       ],
       "title": "Client Feedback/Error Rate",
       "transformations": [
+        {
+          "id": "configFromData",
+          "options": {
+            "configRefId": "B",
+            "mappings": [
+              {
+                "fieldName": "threshold",
+                "handlerKey": "threshold1"
+              }
+            ]
+          }
+        },
         {
           "id": "renameByRegex",
           "options": {
@@ -1393,6 +1425,7 @@
         }
       ],
       "options": {
+        "cellHeight": "sm",
         "footer": {
           "countRows": false,
           "enablePagination": false,
@@ -1405,7 +1438,7 @@
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "category": "All categories",
@@ -1593,7 +1626,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.1",
       "targets": [
         {
           "datasource": {
@@ -2263,6 +2296,6 @@
   "timezone": "",
   "title": "CHT Admin Overview",
   "uid": "oa2OfL-Vk",
-  "version": 30,
+  "version": 31,
   "weekStart": ""
 }


### PR DESCRIPTION
## Changes

### Alerts

#### DB Fragmentation

After auditing data across a number of instances it is clear that small  Couch DBs tend to have high fragmentation.  CouchDB compaction [only runs for DBs > 1mb](https://docs.couchdb.org/en/stable/config/compaction.html#smoosh.%7Bchannel-name%7D/min_size) (and we are not really concerned if small DBs are fragmented). So, I have updated this alert to only fire if the DB has `< 1000 docs`.  

#### Message Delivery Rate

There was a bug in this alert rule because it was loading data with multiple separate queries, but it could not join the data together when there is multiple CHT instances configured. So, it would work find when there was only one CHT instance, but would just stay in the "No Data" status when more than one CHT instance was being scraped.

I updated the alert rule to just use one big query that can join the multiple sub-queries together by  the `instance` label value.  

#### Client Feedback/Error Rate

The alerting threshold for this was just hard-coded to `> 4`. However, the actual number of feedback docs you might expect for a deployment is not static. Instead it is heavily dependent on how many users you have.  I have updated the alert to have a dynamic threshold that triggers when the feedback rate is higher than 1 doc per 10 users. So, if an instance has 200 users, the alert threshold is `> 20`.  If an instance has 20 users, the threshold is `> 2`.

### Dashboard

On the Overview dashboard, I updated the `DB Conflicts Rate` and `Client Feedback/Error Rate` panels so that their coloring thresholds match the dynamic level from the Client Feedback/Error Rate alert. Sadly, the dynamic colors in the Grafana panels only seem to support binary green/red. So, there is no longer any yellow level on these panels.

## Testing

### DB Fragmentation

The easiest way to test the DB alert changes is to hack up the fake-cht to return some hard-coded data.

- Edit the [`index.js` file](https://github.com/medic/cht-monitoring/blob/main/development/fake-cht/src/index.js) and update the `getCouchDB` function to be:

    ```js
		const getCouchDb = ({ name, update_sequence, doc_count, doc_del_count, fragmentation }) => ({
		  name,
		  update_sequence: update_sequence,
		  doc_count: doc_count,
		  doc_del_count: doc_del_count,
		  fragmentation: fragmentation,
		});
	```

- Edit your [`initial-response.json` file](https://github.com/medic/cht-monitoring/blob/main/development/fake-cht/initial-response.json) to set the desired constant values for the `couchdb` object.  E.g:

	```json
	    "medic": {
	      "name": "medic",
	      "update_sequence": 5350893,
	      "doc_count": 10000,
	      "doc_del_count": 38118,
	      "fragmentation": 10.446299875246408
	    },
	    "sentinel": {
	      "name": "medic-sentinel",
	      "update_sequence": 5252663,
	      "doc_count": 5000,
	      "doc_del_count": 38222,
	      "fragmentation": 3.0206934190548345
	    },
	    "usersmeta": {
	      "name": "medic-users-meta",
	      "update_sequence": 5228371,
	      "doc_count": 2500,
	      "doc_del_count": 38444,
	      "fragmentation": 9.031214446418504
	    },
	    "users": {
	      "name": "_users",
	      "update_sequence": 5340790,
	      "doc_count": 10,
	      "doc_del_count": 38178,
	      "fragmentation": 8.516894610225162
	    }
	```

- Be sure to delete the `development/fake-cht/last-response.json` file if it exists
- Then when you start the fake-cht container, the couchdb metrics should stay constant at the values you set.

The DB Fragmentation alert should be triggered for any db with a fragmentation `> 8` and doc_count `> 1000`.  With the example data from above, `medic`, `usersmeta`, and `users` all have fragmentation `> 8`, but `users` only has `10` docs. So, alerts should only trigger for `medic` and `usersmeta`.

### Message Delivery Rate

To test the Message Delivery Rate, simply configure multiple CHT instances in your `cht-instances.yml` file.  Then view the Alert Rule in the Grafana UI: http://localhost:3000/alerting/grafana/0R-OsCYVz/view and verify that the "State" shown in "Matching Instances" is NOT `NoData`.  (Normal/Alerting/Pending is fine. Just not NoData.)

Good:

![image](https://user-images.githubusercontent.com/8441903/235987545-727909be-3418-4b10-9cc4-414f06396669.png)

Bad: 

![image](https://user-images.githubusercontent.com/8441903/235987657-5aa6f362-e554-40bb-b1c9-fa387c01a05f.png)

### Dashboard Panels

You should be able to test the dashboard panel coloring with some similar hacking of the fake-cht as the `DB Fragmentation` alert test.  Basically update the `index.js` `getConnectedUsers` function to be:

```.js
const getConnectedUsers = ({ count }) => ({
  count,
});
```

Then, in your  [`initial-response.json` file](https://github.com/medic/cht-monitoring/blob/main/development/fake-cht/initial-response.json) you can adjust the `connected_users.count` value.  A _small_ value (e.g. `5`) should result in both  the `DB Conflicts Rate` and `Client Feedback/Error Rate` panels turning red since their threshold will be low with so few users.  A very _large_ value (e.g. 555555555) should result in the panels turning green since the threashold is higher for so many users.