### PR TITLE
feat(53): add recommended method for deleting provisioned alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cht-instances.yml
 postgres-instances.yml
 postgres_exporter.yml
 grafana.ini
+delete-rules.yml

--- a/development/README.md
+++ b/development/README.md
@@ -71,11 +71,11 @@ If you are scraping a resource that natively supports returning Prometheus metri
 
 See the existing exporters for examples.
 
-To start the cht-monitoring services with your new exporter configuration, simply use `-f` to include your new docker compose file when starting the services.
+To start the cht-watchdog services with your new exporter configuration, simply use `-f` to include your new docker compose file when starting the services.
 
 ## Adding/modifying Grafana resources
 
-Consumers of cht-monitoring cannot edit the provisioned Grafana configuration (for dashboards and alerts) directly. This means that we can continue to evolve the configuration without worrying about breaking existing deployments. 
+Consumers of cht-watchdog cannot edit the provisioned Grafana configuration (for dashboards and alerts) directly. This means that we can continue to evolve the configuration without worrying about breaking existing deployments. 
 
 ### Dashboards
 
@@ -139,7 +139,7 @@ Each test is associated with an `xlsx` file in this directory that contains the 
 
 #### Running a test
 
-Start a fresh deployment of cht-monitoring without providing any CHT URL and with the test override:
+Start a fresh deployment of cht-watchdog without providing any CHT URL and with the test override:
 
 ```
 docker compose -f docker-compose.yml -f exporters/postgres/docker-compose.postgres-exporter.yml -f development/fake-cht/docker-compose.fake-cht.yml up -d

--- a/development/README.md
+++ b/development/README.md
@@ -117,6 +117,13 @@ cp development/fake-cht/example-config/cht-instances.yml cht-instances.yml
 cp development/fake-cht/example-config/postgres* ./exporters/postgres
 ```
 
+You will also need to run a few additional commands from the [normal setup process](https://docs.communityhealthtoolkit.org/apps/guides/hosting/monitoring/setup/#setup) to prepare your new instance:
+
+```shell
+cp grafana/grafana.example.ini grafana/grafana.ini
+mkdir -p grafana/data && mkdir  -p prometheus/data 
+```
+
 #### Deploy
 
 From the root directory, run:

--- a/development/docker-compose.smtp.yml
+++ b/development/docker-compose.smtp.yml
@@ -6,5 +6,5 @@ services:
     ports:
       - "1080:1080"
     networks:
-      - cht-monitoring-net
+      - cht-watchdog-net
     restart: always

--- a/development/fake-cht/docker-compose.fake-cht.yml
+++ b/development/fake-cht/docker-compose.fake-cht.yml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./development/fake-cht:/home/node/app
     networks:
-      - cht-monitoring-net
+      - cht-watchdog-net
     command: >
       sh -c "npm install &&
              npm start"
@@ -25,4 +25,4 @@ services:
     volumes:
       - fake-cht-postgres-data:/var/lib/postgresql/data
     networks:
-      - cht-monitoring-net
+      - cht-watchdog-net

--- a/development/fake-cht/package-lock.json
+++ b/development/fake-cht/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "fake-cht",
       "dependencies": {
         "express": "^4.18.2",
         "pg": "^8.10.0"

--- a/development/fake-cht/package.json
+++ b/development/fake-cht/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "fake-cht",
   "scripts": {
     "start": "node src/index.js"
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - ./exporters/json/config/scrape_config.yml:/etc/prometheus/scrape_configs/cht-json.yml:ro
       - prometheus-data:/prometheus
     networks:
-      - cht-monitoring-net
+      - cht-watchdog-net
     restart: always
 
   grafana:
@@ -47,7 +47,7 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
       - GF_INSTALL_PLUGINS=${GRAFANA_PLUGINS:-grafana-discourse-datasource}
     networks:
-      - cht-monitoring-net
+      - cht-watchdog-net
     restart: always
 
   json-exporter:
@@ -55,8 +55,8 @@ services:
     volumes:
       - ./exporters/json/config/cht.yml:/config.yml:ro
     networks:
-      - cht-monitoring-net
+      - cht-watchdog-net
     restart: always
 
 networks:
-  cht-monitoring-net:
+  cht-watchdog-net:

--- a/exporters/postgres/docker-compose.postgres-exporter.yml
+++ b/exporters/postgres/docker-compose.postgres-exporter.yml
@@ -15,5 +15,5 @@ services:
       - ./exporters/postgres/postgres_exporter.yml:/etc/postgres-exporter/postgres_exporter.yml:ro
       - ./exporters/postgres/config/cht-queries.yml:/etc/postgres-exporter/queries.yml:ro
     networks:
-      - cht-monitoring-net
+      - cht-watchdog-net
     restart: always

--- a/grafana/provisioning/alerting/delete-rules.example.yml
+++ b/grafana/provisioning/alerting/delete-rules.example.yml
@@ -1,0 +1,5 @@
+apiVersion: 1
+
+# List of provisioned alert rule UIDs that should be deleted
+deleteRules:
+#  - uid: *RULE_UID*

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "version": "1.2.1",
   "repository": {
     "type": "git",
-    "url": "https://github.com/medic/cht-monitoring.git"
+    "url": "https://github.com/medic/cht-watchdog.git"
   }
 }


### PR DESCRIPTION
## Changes

- Adds `delete-rules.example.yml` file that can be copied and used to delete provisioned alert rules.
- Updates the Docker network name `cht-monitoring-net` to be `cht-watchdog-net`.
- Updates random references to CHT Monitoring to be "Watchdog".
- Fix repo link in package.json to point to https://github.com/medic/cht-watchdog.git
- Adds `name` property to fake-cht package.json file.  This should prevent the package-lock.json file getting updated when the fake-cht is built in the docker container.

## Test steps

### Docker network name change

Need to verify that everything still runs as expected and an in-place upgrade of an existing deployment goes smooth.

- Start by checking out the latest from `main`
- Run the [full test config](https://github.com/medic/cht-watchdog/tree/main/development#stream-random-data) for cht-watchdog
  - Make sure data is displayed on the "Couch2pg Backlog" panel.  This indicates that everything is up and working.
- Checkout the `53_delete_alerts` branch
- Run the Docker commands that are [documented for a CHT Watchdog upgrade](https://docs.communityhealthtoolkit.org/apps/guides/hosting/monitoring/setup/#cht-watchdog)

  ```shell
  docker compose pull
  docker compose down
  docker compose -f docker-compose.yml -f exporters/postgres/docker-compose.postgres-exporter.yml -f development/fake-cht/docker-compose.fake-cht.yml up -d --remove-orphans
  ```

- Verify that data is still displayed on the "Couch2pg Backlog" panel.  This indicates that everything is up and working.

### Removing provisioned alert

To test removing a provisioned alert, simply follow the steps documented in the [Docs PR](https://github.com/medic/cht-docs/pull/1082) to remove one of the alert rules. Confirm that the alert rule is no longer visible in Grafana.

---

https://github.com/medic/cht-docs/pull/1082

Closes #53 