### PR TITLE
fix(#35): fix DB Fragmentation alert on multi-instance deployments

### DIFF
--- a/grafana/provisioning/alerting/cht.yml
+++ b/grafana/provisioning/alerting/cht.yml
@@ -16,7 +16,7 @@ groups:
             datasourceUid: PBFA97CFB590B2093
             model:
               editorMode: code
-              expr: cht_couchdb_fragmentation and on (db) (cht_couchdb_doc_total > 1000)
+              expr: cht_couchdb_fragmentation and on (db, instance) (cht_couchdb_doc_total > 1000)
               hide: false
               intervalMs: 1000
               legendFormat: __auto


### PR DESCRIPTION
So, there was a bug in my fix for the DB Fragmentation alert in #37.  The query for the alert rule was not joining on the `instance` label when checking to be sure `cht_couchdb_doc_total > 1000`. It was only checking the `db` label.  But that meant that if _any of the instances_ being scraped by the Watchdog instance had a DB (e.g. a `_users` db) with more than 1000 docs, then the alert would still fire for that `_users` db for _all instances_. 

See [this custom alert rule](https://allies-monitoring-alerting.dev.medicmobile.org/alerting/grafana/e5fefa7f-a8aa-4e71-b899-534a3eba8021/view?returnTo=%2Falerting%2Flist) as an example of what things will look like once these changes are applied (spoiler alert, it is not firing for _any_ of the instances tracked on allies-monitoring....)!