### PR TITLE
fix(#55): support postgres <10

### DIFF
--- a/exporters/postgres/docker-compose.postgres-exporter.yml
+++ b/exporters/postgres/docker-compose.postgres-exporter.yml
@@ -9,6 +9,7 @@ services:
     image: prometheuscommunity/postgres-exporter:${POSTGRES_EXPORTER_VERSION:-latest}
     command:
       - '--config.file=/etc/postgres-exporter/postgres_exporter.yml'
+      - '--no-collector.replication_slot'
     environment:
       - PG_EXPORTER_EXTEND_QUERY_PATH=/etc/postgres-exporter/queries.yml
     volumes:

--- a/exporters/postgres/docker-compose.postgres-exporter.yml
+++ b/exporters/postgres/docker-compose.postgres-exporter.yml
@@ -9,6 +9,7 @@ services:
     image: prometheuscommunity/postgres-exporter:${POSTGRES_EXPORTER_VERSION:-latest}
     command:
       - '--config.file=/etc/postgres-exporter/postgres_exporter.yml'
+      # disables the collection of logical replication metrics to keep the exporter working with Postgres 9.6 (https://github.com/medic/cht-watchdog/issues/55)
       - '--no-collector.replication_slot'
     environment:
       - PG_EXPORTER_EXTEND_QUERY_PATH=/etc/postgres-exporter/queries.yml


### PR DESCRIPTION
Wrote a bit about this [in the issue](https://github.com/medic/cht-watchdog/issues/55#issuecomment-1587092568) but basically the problem seems to be coming from [this logical replication metrics query](https://github.com/prometheus-community/postgres_exporter/blob/master/collector/replication_slots.go#L53-L59) and disabling the related metrics collector makes the exporter not crash anymore when connected to a Postgres <10 instance.