### PR TITLE
feat(#52): set dynamic threshold for Outbound Push Backlog

### DIFF
--- a/development/patches/apply/grafana.provisioning.alerting.cht.yml.patch
+++ b/development/patches/apply/grafana.provisioning.alerting.cht.yml.patch
@@ -18,7 +18,7 @@
         - uid: ot6lYCYVz
           title: DB Fragmentation
 ***************
-*** 439,445 ****
+*** 430,436 ****
     - orgId: 1
       name: 1m
       folder: CHT
@@ -26,7 +26,7 @@
       rules:
         - uid: Q1A-BjL4k
           title: API Server Down
---- 439,445 ----
+--- 430,436 ----
     - orgId: 1
       name: 1m
       folder: CHT

--- a/development/patches/revert/grafana.provisioning.alerting.cht.yml.patch
+++ b/development/patches/revert/grafana.provisioning.alerting.cht.yml.patch
@@ -18,7 +18,7 @@
         - uid: ot6lYCYVz
           title: DB Fragmentation
 ***************
-*** 439,445 ****
+*** 430,436 ****
     - orgId: 1
       name: 1m
       folder: CHT
@@ -26,7 +26,7 @@
       rules:
         - uid: Q1A-BjL4k
           title: API Server Down
---- 439,445 ----
+--- 430,436 ----
     - orgId: 1
       name: 1m
       folder: CHT

--- a/development/tests/integration/alerting/outbound-push-backlog.spec.js
+++ b/development/tests/integration/alerting/outbound-push-backlog.spec.js
@@ -2,23 +2,22 @@ const prometheus = require('../utils/prometheus');
 const grafana = require('../utils/grafana');
 const { expect } = require('chai');
 
-const ALERT_RULE_NAME = 'Sentinel Backlog';
+const ALERT_RULE_NAME = 'Outbound Push Backlog';
 
-describe('Sentinel Backlog alert rule', () => {
-
+describe('Outbound Push Backlog alert rule', () => {
   [
-    [499, 10, 'Normal'],
-    [520, 10, 'Pending'],
-    [620, 121, 'Normal'],
-    [620, 100, 'Pending']
+    [9, 100, 'Normal'],
+    [10, 100, 'Pending'],
+    [54, 1000, 'Normal'],
+    [55, 1000, 'Pending']
   ].forEach(([backlogHr, updateSeqHr, state]) => {
-    it(`is [${state}] with sentinel backlog rate [${backlogHr}] and DB change rate [${updateSeqHr}]`, async () => {
+    it(`is [${state}] with outbound push backlog rate [${backlogHr}] and DB change rate [${updateSeqHr}]`, async () => {
       const updateSeq = updateSeqHr * 720; // 720 hours in 30 days
       const endMs = Date.now();
       const startMs = endMs - (1000 * 60 * 60); // 1 hour ago
 
-      const startBacklogCount = prometheus.createMetric('cht_sentinel_backlog_count', 0, startMs);
-      const endBacklogCount = prometheus.createMetric('cht_sentinel_backlog_count', backlogHr, endMs);
+      const startBacklogCount = prometheus.createMetric('cht_outbound_push_backlog_count', 0, startMs);
+      const endBacklogCount = prometheus.createMetric('cht_outbound_push_backlog_count', backlogHr, endMs);
       const backlogMetrics = prometheus.extrapolateMetrics(startBacklogCount, endBacklogCount);
 
       const startUpdateSeq = prometheus.createMetric('cht_couchdb_update_sequence', 0, startMs, { db: 'medic' });

--- a/development/tests/integration/alerting/sentinel-backlog.spec.js
+++ b/development/tests/integration/alerting/sentinel-backlog.spec.js
@@ -5,7 +5,6 @@ const { expect } = require('chai');
 const ALERT_RULE_NAME = 'Sentinel Backlog';
 
 describe('Sentinel Backlog alert rule', () => {
-
   [
     [499, 10, 'Normal'],
     [520, 10, 'Pending'],

--- a/development/tests/integration/mocha-hooks.js
+++ b/development/tests/integration/mocha-hooks.js
@@ -4,6 +4,7 @@ const { applyPatches, revertPatches } = require('../../patches');
 const grafana = require('./utils/grafana');
 const { BUILD_PATH } = require('./utils/constants');
 const { createDirIfNotExists } = require('./utils/files');
+const { resetTestInstance } = require('./utils');
 
 exports.mochaGlobalSetup = async () => {
   await createDirIfNotExists(BUILD_PATH);
@@ -17,4 +18,10 @@ exports.mochaGlobalSetup = async () => {
 exports.mochaGlobalTeardown = async () => {
   await stopWatchdog();
   await revertPatches();
+};
+
+exports.mochaHooks = {
+  afterEach: () => {
+    resetTestInstance();
+  }
 };

--- a/development/tests/integration/utils/grafana.js
+++ b/development/tests/integration/utils/grafana.js
@@ -1,4 +1,5 @@
 const { sleep } = require('./');
+const { getTestInstance } = require('./index');
 
 const GRAFANA_URL = 'http://127.0.0.1:3000';
 const ADMIN_USER = 'medic';
@@ -38,7 +39,7 @@ const waitUntilStarted = async (tries = 0) => {
   }
 };
 
-const getAlert = async (ruleName, instance, tries = 0) => {
+const getAlert = async (ruleName, instance = getTestInstance(), tries = 0) => {
   if (tries > 30) {
     throw new Error(`Could not find any alert for Rule: ${ruleName}.`);
   }

--- a/development/tests/integration/utils/grafana.js
+++ b/development/tests/integration/utils/grafana.js
@@ -1,5 +1,5 @@
 const { sleep } = require('./');
-const { getTestInstance } = require('./index');
+const { getTestInstance } = require('../utils');
 
 const GRAFANA_URL = 'http://127.0.0.1:3000';
 const ADMIN_USER = 'medic';

--- a/development/tests/integration/utils/index.js
+++ b/development/tests/integration/utils/index.js
@@ -1,5 +1,18 @@
+let testInstance;
+
+const getTestInstance = () => {
+  if (!testInstance) {
+    testInstance = `test-instance-${Date.now()}`;
+  }
+  return testInstance;
+};
+
+const resetTestInstance = () => testInstance = null;
+
 const sleep = (ms) => new Promise(r => setTimeout(r, ms));
 
 module.exports = {
+  getTestInstance,
+  resetTestInstance,
   sleep
 };

--- a/development/tests/integration/utils/prometheus.js
+++ b/development/tests/integration/utils/prometheus.js
@@ -2,6 +2,7 @@ const { execInContainer, restartContainer } = require('./docker');
 const { writeFile } = require('./files');
 const { copyToContainer } = require('./docker');
 const { BUILD_PATH } = require('./constants');
+const { getTestInstance } = require('./index');
 
 const METRIC_SRC_PATH = `${BUILD_PATH}/test-metrics.txt`;
 const METRIC_DEST_PATH = '/prometheus/test-metrics.txt';
@@ -29,11 +30,11 @@ const injectMetrics = async (data) => {
   await restartContainer('prometheus');
 };
 
-const createMetric = (metricName, instance, value = 0, millis = Date.now()) => ({
+const createMetric = (metricName, value, millis, labels = {}) => ({
   metricName,
   value,
   timestamp: millis / 1000,
-  labels: { instance, job: 'cht' }
+  labels: { instance: getTestInstance(), job: 'cht', ...labels }
 });
 
 const extrapolateMetrics = (startMetric, endMetric) => {

--- a/development/tests/integration/utils/prometheus.js
+++ b/development/tests/integration/utils/prometheus.js
@@ -2,7 +2,7 @@ const { execInContainer, restartContainer } = require('./docker');
 const { writeFile } = require('./files');
 const { copyToContainer } = require('./docker');
 const { BUILD_PATH } = require('./constants');
-const { getTestInstance } = require('./index');
+const { getTestInstance } = require('../utils');
 
 const METRIC_SRC_PATH = `${BUILD_PATH}/test-metrics.txt`;
 const METRIC_DEST_PATH = '/prometheus/test-metrics.txt';

--- a/grafana/provisioning/alerting/cht.yml
+++ b/grafana/provisioning/alerting/cht.yml
@@ -95,82 +95,73 @@ groups:
         isPaused: false
       - uid: KgP8PjY4k
         title: Outbound Push Backlog
-        condition: C
+        condition: A
         data:
-          - refId: A
+          - refId: backlog_hr
             relativeTimeRange:
               from: 600
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
+              datasource:
+                type: prometheus
+                uid: PBFA97CFB590B2093
               editorMode: code
-              expr: cht_outbound_push_backlog_count
+              exemplar: false
+              expr: deriv(cht_outbound_push_backlog_count [1h]) * 60 * 60
               hide: false
+              instant: true
               intervalMs: 1000
               legendFormat: __auto
               maxDataPoints: 43200
-              range: true
+              range: false
+              refId: backlog_hr
+          - refId: changes_hr
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              datasource:
+                type: prometheus
+                uid: PBFA97CFB590B2093
+              editorMode: code
+              exemplar: false
+              expr: rate(cht_couchdb_update_sequence{db="medic"}[30d]) * 60 * 60
+              hide: false
+              instant: true
+              intervalMs: 1000
+              legendFormat: __auto
+              maxDataPoints: 43200
+              range: false
+              refId: changes_hr
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: []
+                  reducer:
+                    params: []
+                    type: avg
+                  type: query
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: $backlog_hr > ($changes_hr * 0.05 + 5)
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
               refId: A
-          - refId: B
-            relativeTimeRange:
-              from: 600
-              to: 0
-            datasourceUid: __expr__
-            model:
-              conditions:
-                - evaluator:
-                    params: []
-                    type: gt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                      - B
-                  reducer:
-                    params: []
-                    type: last
-                  type: query
-              datasource:
-                type: __expr__
-                uid: __expr__
-              expression: A
-              hide: false
-              intervalMs: 1000
-              maxDataPoints: 43200
-              reducer: last
-              refId: B
-              settings:
-                mode: ""
-              type: reduce
-          - refId: C
-            relativeTimeRange:
-              from: 600
-              to: 0
-            datasourceUid: __expr__
-            model:
-              conditions:
-                - evaluator:
-                    params:
-                      - 9
-                    type: gt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                      - C
-                  reducer:
-                    params: []
-                    type: last
-                  type: query
-              datasource:
-                type: __expr__
-                uid: __expr__
-              expression: B
-              hide: false
-              intervalMs: 1000
-              maxDataPoints: 43200
-              refId: C
-              type: threshold
+              type: math
         dashboardUid: oa2OfL-Vk
         panelId: 2
         noDataState: NoData

--- a/grafana/provisioning/dashboards/CHT/cht_admin_details.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_details.json
@@ -683,7 +683,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red"
+                    "color": "red",
+                    "value": null
                   },
                   {
                     "color": "blue",
@@ -699,7 +700,7 @@
             "h": 3,
             "w": 5,
             "x": 0,
-            "y": 10
+            "y": 26
           },
           "id": 36,
           "options": {
@@ -716,7 +717,7 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.4.7",
+          "pluginVersion": "9.5.2",
           "targets": [
             {
               "datasource": {
@@ -906,7 +907,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "#EAB839",
@@ -926,7 +928,7 @@
             "h": 6,
             "w": 9,
             "x": 15,
-            "y": 10
+            "y": 26
           },
           "id": 68,
           "options": {
@@ -1013,7 +1015,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   }
                 ]
               }
@@ -1024,7 +1027,7 @@
             "h": 9,
             "w": 5,
             "x": 0,
-            "y": 13
+            "y": 29
           },
           "id": 41,
           "options": {
@@ -1110,19 +1113,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
                     "color": "green",
-                    "value": 0
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 5
-                  },
-                  {
-                    "color": "red",
-                    "value": 10
+                    "value": null
                   }
                 ]
               },
@@ -1134,7 +1126,7 @@
             "h": 6,
             "w": 10,
             "x": 5,
-            "y": 16
+            "y": 32
           },
           "id": 66,
           "options": {
@@ -1161,10 +1153,36 @@
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "rate(cht_couchdb_update_sequence{db=\"medic\"}[30d]) * 60 * 60",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "threshold",
+              "range": false,
+              "refId": "changes_hr"
             }
           ],
           "title": "Outbound Push Backlog",
           "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "configRefId": "changes_hr",
+                "mappings": [
+                  {
+                    "fieldName": "threshold",
+                    "handlerKey": "threshold1"
+                  }
+                ]
+              }
+            },
             {
               "id": "renameByRegex",
               "options": {
@@ -1222,7 +1240,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "blue"
+                    "color": "blue",
+                    "value": null
                   }
                 ]
               },
@@ -1234,7 +1253,7 @@
             "h": 6,
             "w": 9,
             "x": 15,
-            "y": 16
+            "y": 32
           },
           "id": 29,
           "options": {
@@ -2516,6 +2535,6 @@
   "timezone": "",
   "title": "CHT Admin Details",
   "uid": "hkQUbyfVk",
-  "version": 39,
+  "version": 40,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/CHT/cht_admin_details.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_details.json
@@ -1161,7 +1161,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "rate(cht_couchdb_update_sequence{db=\"medic\"}[30d]) * 60 * 60",
+              "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60",
               "hide": false,
               "instant": true,
               "legendFormat": "threshold",

--- a/grafana/provisioning/dashboards/CHT/cht_admin_details.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_details.json
@@ -700,7 +700,7 @@
             "h": 3,
             "w": 5,
             "x": 0,
-            "y": 26
+            "y": 2
           },
           "id": 36,
           "options": {
@@ -717,7 +717,7 @@
             },
             "textMode": "auto"
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "10.0.0",
           "targets": [
             {
               "datasource": {
@@ -796,7 +796,7 @@
             "h": 6,
             "w": 10,
             "x": 5,
-            "y": 26
+            "y": 2
           },
           "id": 69,
           "options": {
@@ -928,7 +928,7 @@
             "h": 6,
             "w": 9,
             "x": 15,
-            "y": 26
+            "y": 2
           },
           "id": 68,
           "options": {
@@ -1027,7 +1027,7 @@
             "h": 9,
             "w": 5,
             "x": 0,
-            "y": 29
+            "y": 5
           },
           "id": 41,
           "options": {
@@ -1126,7 +1126,7 @@
             "h": 6,
             "w": 10,
             "x": 5,
-            "y": 32
+            "y": 8
           },
           "id": 66,
           "options": {
@@ -1161,7 +1161,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60",
+              "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60 * 0.05 + 5",
               "hide": false,
               "instant": true,
               "legendFormat": "threshold",
@@ -1253,7 +1253,7 @@
             "h": 6,
             "w": 9,
             "x": 15,
-            "y": 32
+            "y": 8
           },
           "id": 29,
           "options": {

--- a/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
@@ -106,7 +106,7 @@
         "content": "# CHT Watchdog\n\nSee the [CHT documentation](https://docs.communityhealthtoolkit.org/apps/guides/hosting/monitoring/) for more information about monitoring and alerting!",
         "mode": "markdown"
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "type": "text"
     },
     {
@@ -181,7 +181,7 @@
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -374,7 +374,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -459,7 +459,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -558,7 +558,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -638,7 +638,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -762,7 +762,7 @@
         "showUnfilled": true,
         "valueMode": "color"
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -867,7 +867,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -955,7 +955,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -977,7 +977,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60",
+          "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60 * 0.05 + 5",
           "hide": false,
           "instant": true,
           "legendFormat": "threshold",
@@ -1062,7 +1062,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -1179,7 +1179,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": false
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -1291,7 +1291,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {
@@ -1468,7 +1468,7 @@
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "category": "All categories",
@@ -1656,7 +1656,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.5.2",
+      "pluginVersion": "10.0.0",
       "targets": [
         {
           "datasource": {

--- a/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
@@ -920,20 +920,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": null
-              },
-              {
                 "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 5
-              },
-              {
-                "color": "red",
-                "value": 10
+                "value": null
               }
             ]
           },
@@ -980,10 +968,38 @@
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
-          "refId": "A"
+          "refId": "backlog"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(cht_couchdb_update_sequence{db=\"medic\"}[30d]) * 60 * 60",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "threshold",
+          "range": false,
+          "refId": "changes_hr"
         }
       ],
       "title": "Outbound Push Backlog",
+      "transformations": [
+        {
+          "id": "configFromData",
+          "options": {
+            "configRefId": "changes_hr",
+            "mappings": [
+              {
+                "fieldName": "threshold",
+                "handlerKey": "threshold1"
+              }
+            ]
+          }
+        }
+      ],
       "type": "gauge"
     },
     {
@@ -2310,6 +2326,6 @@
   "timezone": "",
   "title": "CHT Admin Overview",
   "uid": "oa2OfL-Vk",
-  "version": 32,
+  "version": 33,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
@@ -977,7 +977,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "rate(cht_couchdb_update_sequence{db=\"medic\"}[30d]) * 60 * 60",
+          "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60",
           "hide": false,
           "instant": true,
           "legendFormat": "threshold",


### PR DESCRIPTION
#52 

Similar to the #58 PR, the goal of these changes is to make the Outbound Backlog alert rule more useful for instances over variable size.

With the new alert logic we will trigger Outbound Push Backlog alerts: _if the backlog is increasing by more than 5% of the the changes rate (with a 5 change minimum buffer). This indicates that a significant percentage of changes are not being properly processed by the outbound push logic._

In addition, I have updated the Outbound Push Backlog panels on both the Overview and Details dashboards to dynamically set the color based on the change rate of the database.

## Testing considerations

### Alert rule

See the [Outbound Push Backlog (jkuester)](https://allies-monitoring-alerting.dev.medicmobile.org/alerting/grafana/d4f818b0-b885-4d16-8089-ddb97cd12a4f/view?returnTo=%2Falerting%2Flist) alert rule on the Allies instace for a live example of the new logic!

Also, if you want to get a historical view of when this alert would have been triggered, you can use this query our on the Grafana Explore page: 

```
(deriv(cht_outbound_push_backlog_count [1h]) * 60 * 60) > on(instance) ((rate(cht_couchdb_update_sequence{db="medic"}[30d]) * 60 * 60) * 0.05 + 5)
```

I have also included new automated tests for the alert rule.

### Dashboards

To manually test the dashboards on a fake instance:

- Run this query on the Explore page to get your current change rate (it will change over time): `rate(cht_couchdb_update_sequence{db="medic"}[30d]) * 60 * 60`
- Update the fake-cht index.js to return a value for the outbound push backlog that is higher/lower than your change rate
- Restart the fake-cht container
- See the colors on the dashboards change for the "Outbound Push Backlog" panels.