### PR TITLE
fix(#63): fix Sentinel Backlog panels for multiple CHT instances

### DIFF
--- a/grafana/provisioning/dashboards/CHT/cht_admin_details.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_details.json
@@ -829,7 +829,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60",
+              "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60 + 500",
               "hide": false,
               "legendFormat": "threshold",
               "range": true,

--- a/grafana/provisioning/dashboards/CHT/cht_admin_details.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_details.json
@@ -829,7 +829,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "rate(cht_couchdb_update_sequence{db=\"medic\"}[30d]) * 60 * 60",
+              "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60",
               "hide": false,
               "legendFormat": "threshold",
               "range": true,

--- a/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
@@ -1067,7 +1067,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60",
+          "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60 + 500",
           "hide": false,
           "legendFormat": "threshold",
           "range": true,

--- a/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
@@ -1067,7 +1067,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "rate(cht_couchdb_update_sequence{db=\"medic\"}[30d]) * 60 * 60",
+          "expr": "rate(cht_couchdb_update_sequence{db=\"medic\", instance=~\"$cht_instance\"}[30d]) * 60 * 60",
           "hide": false,
           "legendFormat": "threshold",
           "range": true,


### PR DESCRIPTION
Closes #63 

Simple change to just add filtering by the `instance` label to the new queries introduced in #58.  This should correct the behavior of the panels on instances recording data for multiple CHT instances.

## Testing considerations

To test these changes locally, just make sure you have multiple CHT instances configured in your `cht-instances.yml`.  E.g.:

```yaml
- targets:
    # Update this URL to point to your CHT instance.
    # Add additional URLs to monitor multiple instances.
    - http://fake-cht:8081
    - https://gamma.dev.medicmobile.org
```

Then, if you spin up the `main` branch you will see multiple gauges displayed on the Overview dashboard for the Sentinel Backlog panel (as noted in the issue).  

Deploy the `52_fix_sentinel_backlog_panesl` branch, and you should see the panel go back to only displaying 1 gauge as expected (and the gauge should update the data is displays when you change the selected CHT instance.