### PR TITLE
feat(#52): set dynamic threshold for Users Over Rep Limit

### DIFF
--- a/development/patches/apply/grafana.provisioning.alerting.cht.yml.patch
+++ b/development/patches/apply/grafana.provisioning.alerting.cht.yml.patch
@@ -18,7 +18,7 @@
         - uid: ot6lYCYVz
           title: DB Fragmentation
 ***************
-*** 430,436 ****
+*** 421,427 ****
     - orgId: 1
       name: 1m
       folder: CHT
@@ -26,7 +26,7 @@
       rules:
         - uid: Q1A-BjL4k
           title: API Server Down
---- 430,436 ----
+--- 421,427 ----
     - orgId: 1
       name: 1m
       folder: CHT

--- a/development/patches/revert/grafana.provisioning.alerting.cht.yml.patch
+++ b/development/patches/revert/grafana.provisioning.alerting.cht.yml.patch
@@ -18,7 +18,7 @@
         - uid: ot6lYCYVz
           title: DB Fragmentation
 ***************
-*** 430,436 ****
+*** 421,427 ****
     - orgId: 1
       name: 1m
       folder: CHT
@@ -26,7 +26,7 @@
       rules:
         - uid: Q1A-BjL4k
           title: API Server Down
---- 430,436 ----
+--- 421,427 ----
     - orgId: 1
       name: 1m
       folder: CHT

--- a/development/tests/integration/alerting/users-over-replication-limit.spec.js
+++ b/development/tests/integration/alerting/users-over-replication-limit.spec.js
@@ -1,0 +1,33 @@
+const prometheus = require('../utils/prometheus');
+const grafana = require('../utils/grafana');
+const { expect } = require('chai');
+
+const ALERT_RULE_NAME = 'Users Over Replication Limit';
+
+describe('Users Over Replication Limit alert rule', () => {
+  [
+    [2, 100, 'Normal'],
+    [3, 100, 'Pending'],
+    [31, 10000, 'Normal'],
+    [32, 10000, 'Pending']
+  ].forEach(([usersOverLimit, userCount, state]) => {
+    it(`is [${state}] with users over rep limit rate [${usersOverLimit}] and [${userCount}] users`, async () => {
+      const endMs = Date.now();
+      const startMs = endMs - (1000 * 60 * 60 * 24); // 1 day ago
+
+      const startUsersOverLimitCount = prometheus.createMetric('cht_replication_limit_count', 0, startMs);
+      const endUsersOverLimitCount = prometheus.createMetric('cht_replication_limit_count', usersOverLimit, endMs);
+      const replicationLimitMetrics = prometheus.extrapolateMetrics(startUsersOverLimitCount, endUsersOverLimitCount);
+
+      const startUserCount = prometheus.createMetric('cht_connected_users_count', 0, startMs);
+      const endUserCount = prometheus.createMetric('cht_couchdb_update_sequence', userCount, endMs);
+      const userCountMetrics = prometheus.extrapolateMetrics(startUserCount, endUserCount);
+
+      await prometheus.injectMetrics([...replicationLimitMetrics, ...userCountMetrics]);
+
+      const alert = await grafana.getAlert(ALERT_RULE_NAME);
+
+      expect(alert.state).to.equal(state);
+    });
+  });
+});

--- a/grafana/provisioning/alerting/cht.yml
+++ b/grafana/provisioning/alerting/cht.yml
@@ -341,82 +341,73 @@ groups:
         isPaused: false
       - uid: ttAeECYVz
         title: Users Over Replication Limit
-        condition: C
+        condition: alert
         data:
-          - refId: A
+          - refId: users_day
             relativeTimeRange:
               from: 600
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
+              datasource:
+                type: prometheus
+                uid: PBFA97CFB590B2093
               editorMode: code
-              expr: cht_replication_limit_count
+              exemplar: false
+              expr: deriv(cht_replication_limit_count [1d]) * 60 * 60 * 24
               hide: false
+              instant: true
               intervalMs: 1000
               legendFormat: __auto
               maxDataPoints: 43200
-              range: true
-              refId: A
-          - refId: B
+              range: false
+              refId: users_day
+          - refId: users
             relativeTimeRange:
               from: 600
               to: 0
-            datasourceUid: __expr__
+            datasourceUid: PBFA97CFB590B2093
             model:
-              conditions:
-                - evaluator:
-                    params: []
-                    type: gt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                      - B
-                  reducer:
-                    params: []
-                    type: last
-                  type: query
               datasource:
-                type: __expr__
-                uid: __expr__
-              expression: A
+                type: prometheus
+                uid: PBFA97CFB590B2093
+              editorMode: code
+              exemplar: false
+              expr: cht_connected_users_count
               hide: false
+              instant: true
               intervalMs: 1000
+              legendFormat: __auto
               maxDataPoints: 43200
-              reducer: last
-              refId: B
-              settings:
-                mode: ""
-              type: reduce
-          - refId: C
-            relativeTimeRange:
-              from: 600
-              to: 0
+              range: false
+              refId: users
+          - refId: alert
             datasourceUid: __expr__
             model:
               conditions:
                 - evaluator:
                     params:
-                      - 9
+                      - 0
+                      - 0
                     type: gt
                   operator:
                     type: and
                   query:
-                    params:
-                      - C
+                    params: []
                   reducer:
                     params: []
-                    type: last
+                    type: avg
                   type: query
               datasource:
+                name: Expression
                 type: __expr__
                 uid: __expr__
-              expression: B
+              expression: $users_day > ($users * 0.003 + 2)
               hide: false
               intervalMs: 1000
               maxDataPoints: 43200
-              refId: C
-              type: threshold
+              refId: alert
+              type: math
         dashboardUid: oa2OfL-Vk
         panelId: 21
         noDataState: NoData

--- a/grafana/provisioning/dashboards/CHT/cht_admin_details.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_details.json
@@ -909,14 +909,6 @@
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "#EAB839",
-                    "value": 1
-                  },
-                  {
-                    "color": "red",
-                    "value": 10
                   }
                 ]
               },
@@ -953,11 +945,37 @@
               "expr": "cht_replication_limit_count{instance=~\"$cht_instance\"}",
               "legendFormat": "__auto",
               "range": true,
-              "refId": "A"
+              "refId": "users_over_limit"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "cht_connected_users_count{instance=~\"$cht_instance\"} * 0.003 + 2",
+              "hide": false,
+              "instant": true,
+              "legendFormat": "users_threshold",
+              "range": false,
+              "refId": "users_threshold"
             }
           ],
           "title": "Users Over Replication Limit",
           "transformations": [
+            {
+              "id": "configFromData",
+              "options": {
+                "configRefId": "users_threshold",
+                "mappings": [
+                  {
+                    "fieldName": "users_threshold",
+                    "handlerKey": "threshold1"
+                  }
+                ]
+              }
+            },
             {
               "id": "renameByRegex",
               "options": {
@@ -2535,6 +2553,6 @@
   "timezone": "",
   "title": "CHT Admin Details",
   "uid": "hkQUbyfVk",
-  "version": 40,
+  "version": 41,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
@@ -513,18 +513,6 @@
               {
                 "color": "red",
                 "value": null
-              },
-              {
-                "color": "green",
-                "value": 0
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 10
               }
             ]
           },
@@ -571,10 +559,36 @@
           "instant": true,
           "legendFormat": "__auto",
           "range": false,
-          "refId": "A"
+          "refId": "users_over_limit"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "cht_connected_users_count{instance=~\"$cht_instance\"} * 0.003 + 2",
+          "hide": false,
+          "legendFormat": "users_threshold",
+          "range": true,
+          "refId": "users_threshold"
         }
       ],
       "title": "Users Over Replication Limit",
+      "transformations": [
+        {
+          "id": "configFromData",
+          "options": {
+            "configRefId": "users_threshold",
+            "mappings": [
+              {
+                "fieldName": "users_threshold",
+                "handlerKey": "threshold1"
+              }
+            ]
+          }
+        }
+      ],
       "type": "gauge"
     },
     {
@@ -2326,6 +2340,6 @@
   "timezone": "",
   "title": "CHT Admin Overview",
   "uid": "oa2OfL-Vk",
-  "version": 33,
+  "version": 34,
   "weekStart": ""
 }


### PR DESCRIPTION
#52 

Similar to the #58 and #62 PRs, the goal of these changes is to make the Users Over Replication Limit alert rule more useful for instances over variable size.

With the new alert logic we will trigger Users Over Replication Limit alerts: _if user count is increasing by more than `0.3%` of total users per day (with a 2 user minimum buffer). A meaningful amount of users crossing the replication limit could indicate an issue with recently updated configuration._

In addition, I have updated the Users Over Replication Limit panels on both the Overview and Details dashboards to dynamically set the color based on the user count for the instance.

## Testing considerations

### Alert rule

See the [Users Over Replication Limit (jkuester)](https://allies-monitoring-alerting.dev.medicmobile.org/alerting/grafana/d6284b22-716b-47cb-820e-04d1c8b6617e/view?returnTo=%2Falerting%2Flist) alert rule on the Allies instance for a live example of the new logic!

Also, if you want to get a historical view of when this alert would have been triggered, you can use this query our on the Grafana Explore page: 

```
(deriv(cht_replication_limit_count [1d]) * 60 * 60 * 24) > on(instance) (cht_connected_users_count * 0.003 + 2)
```

I have also included new automated tests for the alert rule.

### Dashboards

To manually test the dashboards on a fake instance:

- Run this query on the Explore page to get your current user threshold (it will change over time): `cht_connected_users_count * 0.003 + 2`
- Update the fake-cht index.js to return a value for the replication limit count that is higher/lower than your user threshold
- Restart the fake-cht container
- See the colors on the dashboards change for the "Users Over Replication Limit" panels.