### PR TITLE
feat(#52): set dynamic threshold for DB Conflicts Rate alert

### DIFF
--- a/development/tests/integration/alerting/db-conflicts-rate.spec.js
+++ b/development/tests/integration/alerting/db-conflicts-rate.spec.js
@@ -1,0 +1,34 @@
+const prometheus = require('../utils/prometheus');
+const grafana = require('../utils/grafana');
+const { expect } = require('chai');
+
+const ALERT_RULE_NAME = 'DB Conflicts Rate';
+
+describe('DB Conflicts Rate alert rule', () => {
+  [
+    [34, 100, 'Normal'],
+    [35, 100, 'Pending'],
+    [259, 1000, 'Normal'],
+    [260, 1000, 'Pending']
+  ].forEach(([backlogHr, updateSeqHr, state]) => {
+    it(`is [${state}] with conflict rate [${backlogHr}] and DB change rate [${updateSeqHr}]`, async () => {
+      const updateSeq = updateSeqHr * 720; // 720 hours in 30 days
+      const endMs = Date.now();
+      const startMs = endMs - (1000 * 60 * 60); // 1 hour ago
+
+      const startConflictCount = prometheus.createMetric('cht_conflict_count', 0, startMs);
+      const endConflictCount = prometheus.createMetric('cht_conflict_count', backlogHr, endMs);
+      const conflictMetrics = prometheus.extrapolateMetrics(startConflictCount, endConflictCount);
+
+      const startUpdateSeq = prometheus.createMetric('cht_couchdb_update_sequence', 0, startMs, { db: 'medic' });
+      const endUpdateSeq = prometheus.createMetric('cht_couchdb_update_sequence', updateSeq, endMs, { db: 'medic' });
+      const updateSeqMetrics = prometheus.extrapolateMetrics(startUpdateSeq, endUpdateSeq);
+
+      await prometheus.injectMetrics([...conflictMetrics, ...updateSeqMetrics]);
+
+      const alert = await grafana.getAlert(ALERT_RULE_NAME);
+
+      expect(alert.state).to.equal(state);
+    });
+  });
+});

--- a/grafana/provisioning/alerting/cht.yml
+++ b/grafana/provisioning/alerting/cht.yml
@@ -591,82 +591,73 @@ groups:
         isPaused: false
       - uid: gli1YjL4k
         title: DB Conflicts Rate
-        condition: C
+        condition: A
         data:
-          - refId: A
+          - refId: conflicts_hr
             relativeTimeRange:
               from: 600
               to: 0
             datasourceUid: PBFA97CFB590B2093
             model:
+              datasource:
+                type: prometheus
+                uid: PBFA97CFB590B2093
               editorMode: code
-              expr: rate(cht_conflict_count[24h]) * 60 * 60 * 24
+              exemplar: false
+              expr: deriv(cht_conflict_count [1h]) * 60 * 60
               hide: false
+              instant: true
               intervalMs: 1000
               legendFormat: __auto
               maxDataPoints: 43200
-              range: true
+              range: false
+              refId: conflicts_hr
+          - refId: changes_hr
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: PBFA97CFB590B2093
+            model:
+              datasource:
+                type: prometheus
+                uid: PBFA97CFB590B2093
+              editorMode: code
+              exemplar: false
+              expr: rate(cht_couchdb_update_sequence{db="medic"}[30d]) * 60 * 60
+              hide: false
+              instant: true
+              intervalMs: 1000
+              legendFormat: __auto
+              maxDataPoints: 43200
+              range: false
+              refId: changes_hr
+          - refId: A
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: []
+                  reducer:
+                    params: []
+                    type: avg
+                  type: query
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: $conflicts_hr > ($changes_hr * 0.25 + 10)
+              hide: false
+              intervalMs: 1000
+              maxDataPoints: 43200
               refId: A
-          - refId: B
-            relativeTimeRange:
-              from: 600
-              to: 0
-            datasourceUid: __expr__
-            model:
-              conditions:
-                - evaluator:
-                    params: []
-                    type: gt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                      - B
-                  reducer:
-                    params: []
-                    type: last
-                  type: query
-              datasource:
-                type: __expr__
-                uid: __expr__
-              expression: A
-              hide: false
-              intervalMs: 1000
-              maxDataPoints: 43200
-              reducer: last
-              refId: B
-              settings:
-                mode: ""
-              type: reduce
-          - refId: C
-            relativeTimeRange:
-              from: 600
-              to: 0
-            datasourceUid: __expr__
-            model:
-              conditions:
-                - evaluator:
-                    params:
-                      - 4
-                    type: gt
-                  operator:
-                    type: and
-                  query:
-                    params:
-                      - C
-                  reducer:
-                    params: []
-                    type: last
-                  type: query
-              datasource:
-                type: __expr__
-                uid: __expr__
-              expression: B
-              hide: false
-              intervalMs: 1000
-              maxDataPoints: 43200
-              refId: C
-              type: threshold
+              type: math
         dashboardUid: oa2OfL-Vk
         panelId: 7
         noDataState: NoData

--- a/grafana/provisioning/dashboards/CHT/cht_admin_details.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_details.json
@@ -164,7 +164,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "continuous-reds"
+            "mode": "thresholds"
           },
           "custom": {
             "axisCenteredZero": false,
@@ -239,10 +239,36 @@
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "rate(cht_couchdb_update_sequence{instance=~\"$cht_instance\", db=\"medic\"}[30d]) * 60 * 60 * 24 * 0.25 + 10",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "threshold",
+          "range": false,
+          "refId": "B"
         }
       ],
       "title": "Total Doc Conflicts",
       "transformations": [
+        {
+          "id": "configFromData",
+          "options": {
+            "configRefId": "B",
+            "mappings": [
+              {
+                "fieldName": "threshold",
+                "handlerKey": "threshold1"
+              }
+            ]
+          }
+        },
         {
           "id": "renameByRegex",
           "options": {
@@ -2553,6 +2579,6 @@
   "timezone": "",
   "title": "CHT Admin Details",
   "uid": "hkQUbyfVk",
-  "version": 41,
+  "version": 42,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
@@ -181,7 +181,7 @@
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "10.0.0",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -672,7 +672,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "cht_connected_users_count{instance=~\"$cht_instance\"} / 10",
+          "expr": "rate(cht_couchdb_update_sequence{instance=~\"$cht_instance\", db=\"medic\"}[30d]) * 60 * 60 * 24 * 0.25 + 10",
           "hide": false,
           "instant": true,
           "legendFormat": "threshold",
@@ -2340,6 +2340,6 @@
   "timezone": "",
   "title": "CHT Admin Overview",
   "uid": "oa2OfL-Vk",
-  "version": 34,
+  "version": 35,
   "weekStart": ""
 }


### PR DESCRIPTION
Closes #52 

Similar to the #58, #62, and #65 PRs, the goal of these changes is to make the DB Conflicts Rate alert rule more useful for instances over variable size.

With the new alert logic we will trigger DB Conflicts Rate alerts: _if the conflict count is increasing faster than 25% of the total database changes (with a 10 doc minimum buffer). This many conflicts being generated represents a huge issue with the configuration (and/or issues with data migration)._

In addition, I have updated the DB Conflicts panels on both the Overview and Details dashboards to dynamically set the color based on the database activity for the instance.

## Testing considerations

### Alert rule

See the [DB Conflicts Rate (jkuester)](https://allies-monitoring-alerting.dev.medicmobile.org/alerting/grafana/be6570f8-e29b-43ad-9699-88ae2b79dd41/view?returnTo=%2Falerting%2Flist) alert rule on the Allies instance for a live example of the new logic!

Also, if you want to get a historical view of when this alert would have been triggered, you can use this query our on the Grafana Explore page: 

```
(deriv(cht_conflict_count [1h]) * 60 * 60) > on (instance) ((rate(cht_couchdb_update_sequence{db="medic"}[30d]) * 60 * 60) * 0.25 + 10)
```

I have also included new automated tests for the alert rule.

### Dashboards

To manually test the dashboards on a fake instance:

- Run this query on the Explore page to get your current DB change rate (it will change over time): `rate(cht_couchdb_update_sequence{db="medic"}[30d]) * 60 * 60 * 24 * 0.25 + 10`
- Update the fake-cht index.js to return a value for the conflicts count that is higher/lower than your user threshold
- Restart the fake-cht container
- See the colors on the dashboards change for the "DB Conflicts" panels.