### PR TITLE
fix(#68): defensive couch2pg select

### DIFF
--- a/exporters/postgres/config/cht-queries.yml
+++ b/exporters/postgres/config/cht-queries.yml
@@ -5,6 +5,9 @@ couch2pg_progress:
       substring(source from position('/' in source) + 1) as db 
     FROM 
       couchdb_progress
+    WHERE
+      source like '%/%' and
+      seq like '%-%'
   metrics:
     - db:
         usage: "LABEL"


### PR DESCRIPTION
This PR adds a `where` clause to the couch2pg status query to ensure the columns contain the data the query expects so the `position` calls don't fail when there's bad data

closes #68