### PR TITLE
Limit scrape_duration_seconds visualization to CHT instance

### DIFF
--- a/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_overview.json
@@ -2052,7 +2052,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "code",
-              "expr": "scrape_duration_seconds",
+              "expr": "scrape_duration_seconds{instance=\"$cht_instance\"}",
               "instant": false,
               "legendFormat": "__auto",
               "range": true,


### PR DESCRIPTION
Limited the values of the Scrape Duration graph to only come from the currently selected CHT instance(`$cht_instance`). This prevents non-related VMs from showing up in a dashboard thats only focused on CHT monitoring.