### PR TITLE
fix(#70): disable all non-custom Postgres metrics

### DIFF
--- a/exporters/postgres/docker-compose.postgres-exporter.yml
+++ b/exporters/postgres/docker-compose.postgres-exporter.yml
@@ -9,8 +9,19 @@ services:
     image: prometheuscommunity/postgres-exporter:${POSTGRES_EXPORTER_VERSION:-latest}
     command:
       - '--config.file=/etc/postgres-exporter/postgres_exporter.yml'
-      # disables the collection of logical replication metrics to keep the exporter working with Postgres 9.6 (https://github.com/medic/cht-watchdog/issues/55)
+      # disables the collection of all metrics except for custom queries (https://github.com/medic/cht-watchdog/issues/70)
+      - '--no-collector.database'
+      - '--no-collector.postmaster'
+      - '--no-collector.process_idle'
+      - '--no-collector.replication'
       - '--no-collector.replication_slot'
+      - '--no-collector.stat_bgwriter'
+      - '--no-collector.stat_database'
+      - '--no-collector.statio_user_tables'
+      - '--no-collector.stat_statements'
+      - '--no-collector.stat_user_tables'
+      - '--disable-default-metrics'
+      - '--disable-settings-metrics'
     environment:
       - PG_EXPORTER_EXTEND_QUERY_PATH=/etc/postgres-exporter/queries.yml
     volumes:


### PR DESCRIPTION
Closes #70

The goal of this PR is to minimize the number of metrics collected from Postgres. This will address 2 problems at the same time! First, the random log errors and other various querying issues when running against crazy old Postgres versions are being triggered when collecting the various default metrics that the postgres_exporter collects about the Postgres instance and its databases.  Turning off these metrics should avoid the errors and quiet the logs.  Secondly, when testing this against the prod Postgres instance, we observed that metric scraping was insanely slow (well above 10sec).  Radically reducing the amount of metrics we are actually collecting from Postgres should help improve the scrape time!

Note that none of the metrics that are being removed were being used in any dashboards or alerts. They were all simply monitoring data that was focused on the Postgres instance itself (and not directly connected to monitoring the health of the CHT instance).  Some of these metrics might be valuable to track in the future (to help understand the health of the Postgres instance), but they can be re-enabled when they are needed.  Currently, when running against the fake instance, the postgres_exporter scrape returns `1153` lines of data in its response to each scrape.  After these changes, the scrape response is only `20` lines (containing just our custom metrics and a few metrics directly connected to the performance of the exporter itself).

Regarding the config changes, it may look redundant to disable all the collectors individually in addition to setting `--disable-default-metrics` and `--disable-settings-metrics`.  The main thing I can say here is that I tested various combinations and this was the way that ultimately resulted in the least amount of metrics being collected.  Based on [this comment](https://github.com/prometheus-community/postgres_exporter/issues/757#issuecomment-1539228643) I believe the postgres_exporter is being gradually being re-factored to use these "collectors" so that going forwards the `disable-*-metrics` flags will be removed, but for now the `disable-*-metrics` flags seem to disable the metrics that have not yet been refactored, while the `no-collector` flags disable to new-style metrics.  :shrug: 

## Testing considerations

The main thing to verify after these changes is that our custom `couch2pg_progress_sequence` metric is still being collected. This can be done by running Watchdog with the fake-cht configuration:

- Set the [development patches](https://github.com/medic/cht-watchdog/tree/main/development#development-patches)
- Configure and deploy Watchdog with the [fake-cht server](https://github.com/medic/cht-watchdog/tree/main/development#stream-random-data)
- Open Grafana (http://localhost:3000/) and navigate to the `CHT Admin Overview` dashboard
- Verify that data is displayed in the `Couch2Pg Backlog` panel (the value is dynamic, but it should not be `No data`)

Additionally, if you want to manually check the response data from the postgres_exporter (e.g. to do a before/after comparison) here is how:

- Set the [development patches](https://github.com/medic/cht-watchdog/tree/main/development#development-patches)
- Configure and deploy Watchdog with the [fake-cht server](https://github.com/medic/cht-watchdog/tree/main/development#stream-random-data)
- Connect to the fake-cht docker container (just a convenient place with access to the docker network): `docker exec -it cht-watchdog-fake-cht-1 bash`
- Run this curl command to simulate a scrape: `curl "http://postgres-exporter:9187/probe?auth_module=postgres%3A5432%2Fcht&target=postgresql%3A%2F%2Fpostgres%3A5432%2Fcht"`