### PR TITLE
feat(compose): make grafana provisioning mount be read/write

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
       - ./grafana/grafana.ini:/etc/grafana/grafana.ini:ro
-      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/provisioning:/etc/grafana/provisioning:rw
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-medic}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-password}


### PR DESCRIPTION
This PR is needed so users who are extending watchdog can do something like this in an additional YAML compose file:

```yaml
services:
  grafana:
    volumes:
      - ./extra-sql-dashboard.json:/etc/grafana/provisioning/dashboards/CHT/cht_admin_extra_sql.json:ro
```

If not, no extra files can be mounted into `/etc/grafana/provisioning` because [it's read only](https://github.com/medic/cht-watchdog/blob/e12c94bb7d7dcb455b3cb0ab3e7c8ab9cfbf5e44/docker-compose.yml#L43).
