### PR TITLE
chore(#80): pin docker images versions to the versions currently used

### DIFF
--- a/development/docker-compose.smtp.yml
+++ b/development/docker-compose.smtp.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   maildev:
-    image: maildev/maildev:latest
+    image: maildev/maildev:2.1.0
     ports:
       - "1080:1080"
     networks:

--- a/development/fake-cht/docker-compose.fake-cht.yml
+++ b/development/fake-cht/docker-compose.fake-cht.yml
@@ -5,7 +5,7 @@ volumes:
 
 services:
   fake-cht:
-    image: node:latest
+    image: node:lts-alpine
     user: "node"
     working_dir: /home/node/app
     volumes:
@@ -17,7 +17,7 @@ services:
              npm start"
 
   postgres:
-    image: postgres:latest
+    image: postgres:15
     environment:
       POSTGRES_DB: cht
       POSTGRES_USER: postgres_root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ volumes:
 
 services:
   prometheus:
-#    image: prom/prometheus:${PROMETHEUS_VERSION:-v2.46.0}
     image: prom/prometheus:${PROMETHEUS_VERSION:-v2.44.0}
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -35,7 +34,6 @@ services:
     restart: always
 
   grafana:
-#    image: grafana/grafana-oss:${GRAFANA_VERSION:-10.0.3}
     image: grafana/grafana-oss:${GRAFANA_VERSION:-9.5.3}
     ports:
       - "${GRAFANA_BIND:-127.0.0.1}:${GRAFANA_PORT:-3000}:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ volumes:
 
 services:
   prometheus:
-    image: prom/prometheus:${PROMETHEUS_VERSION:-latest}
+#    image: prom/prometheus:${PROMETHEUS_VERSION:-v2.46.0}
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v2.44.0}
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
@@ -34,7 +35,8 @@ services:
     restart: always
 
   grafana:
-    image: grafana/grafana-oss:${GRAFANA_VERSION:-latest}
+#    image: grafana/grafana-oss:${GRAFANA_VERSION:-10.0.3}
+    image: grafana/grafana-oss:${GRAFANA_VERSION:-9.5.3}
     ports:
       - "${GRAFANA_BIND:-127.0.0.1}:${GRAFANA_PORT:-3000}:3000"
     volumes:
@@ -51,7 +53,7 @@ services:
     restart: always
 
   json-exporter:
-    image: prometheuscommunity/json-exporter:${JSON_EXPORTER_VERSION:-latest}
+    image: prometheuscommunity/json-exporter:${JSON_EXPORTER_VERSION:-v0.6.0}
     volumes:
       - ./exporters/json/config/cht.yml:/config.yml:ro
     networks:

--- a/exporters/postgres/docker-compose.postgres-exporter.yml
+++ b/exporters/postgres/docker-compose.postgres-exporter.yml
@@ -6,7 +6,7 @@ services:
       - ./exporters/postgres/postgres-instances.yml:/etc/prometheus/postgres-instances.yml:ro
       - ./exporters/postgres/config/scrape_config.yml:/etc/prometheus/scrape_configs/cht-postgres.yml:ro
   postgres-exporter:
-    image: prometheuscommunity/postgres-exporter:${POSTGRES_EXPORTER_VERSION:-0.13.0}
+    image: prometheuscommunity/postgres-exporter:${POSTGRES_EXPORTER_VERSION:-v0.13.0}
     command:
       - '--config.file=/etc/postgres-exporter/postgres_exporter.yml'
       # disables the collection of all metrics except for custom queries (https://github.com/medic/cht-watchdog/issues/70)

--- a/exporters/postgres/docker-compose.postgres-exporter.yml
+++ b/exporters/postgres/docker-compose.postgres-exporter.yml
@@ -6,7 +6,7 @@ services:
       - ./exporters/postgres/postgres-instances.yml:/etc/prometheus/postgres-instances.yml:ro
       - ./exporters/postgres/config/scrape_config.yml:/etc/prometheus/scrape_configs/cht-postgres.yml:ro
   postgres-exporter:
-    image: prometheuscommunity/postgres-exporter:${POSTGRES_EXPORTER_VERSION:-latest}
+    image: prometheuscommunity/postgres-exporter:${POSTGRES_EXPORTER_VERSION:-0.13.0}
     command:
       - '--config.file=/etc/postgres-exporter/postgres_exporter.yml'
       # disables the collection of all metrics except for custom queries (https://github.com/medic/cht-watchdog/issues/70)


### PR DESCRIPTION
No dependabot automation included, as [discussed in the issue](https://github.com/medic/cht-watchdog/issues/80#issuecomment-1680958017)