### PR TITLE
fix(#90): incorrect cht replication dashboard apdex calculations

### DIFF
--- a/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
+++ b/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
@@ -288,7 +288,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(\n\tsum(\n\t\tcht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\",code=~\"^[45]..$\"} OR on() vector(0)\n\t) / \n\tsum(\n\t\tcht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\"}\n\t)\n)*100",
+          "expr": "(\n\t(\n\t\tsum(\n\t\t\tcht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\",code=~\"^[45]..$\"} OR on() vector(0)\n\t\t)\n\t\t+ sum(\n\t\t\tcht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",ge=\"3600\",code=~\"^2..$\"} OR on() vector(0)\n\t\t)\n\t) / \n\tsum(\n\t\tcht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\"}\n\t)\n)*100",
           "legendFormat": "error %",
           "range": true,
           "refId": "A"
@@ -572,7 +572,7 @@
             "value": "2m"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "10m",
             "value": "10m"
           },
@@ -582,7 +582,7 @@
             "value": "30m"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "1h",
             "value": "1h"
           },
@@ -626,7 +626,7 @@
     ]
   },
   "time": {
-    "from": "now-3h",
+    "from": "now-1d",
     "to": "now"
   },
   "timepicker": {

--- a/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
+++ b/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
@@ -67,11 +67,11 @@
               },
               {
                 "color": "rgba(237, 129, 40, 0.89)",
-                "value": 70
+                "value": 80
               },
               {
                 "color": "#299c46",
-                "value": 90
+                "value": 98
               }
             ]
           },
@@ -110,7 +110,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(\n        (   \n                sum(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",le=\"90\",route=~\".*/get-ids\",code=~\"^2..$\"})\n                + (\n                        sum(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",le=\"180\",route=~\".*/get-ids\",code=~\"^2..$\"})\n                        - sum(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",le=\"90\",route=~\".*/get-ids\",code=~\"^2..$\"})\n                ) / 2\n        ) / sum(cht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\",code=~\"^2..$\"})\n) * 100",
+          "expr": "(\n        (   \n                sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$\"}[$__range]))\n                + (\n                        sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"360\",code=~\"^2..$\"}[$__range]))\n                        - sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$\"}[$__range]))\n                ) / 2\n        ) / sum(delta(cht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\"}[$__range]))\n) * 100",
           "legendFormat": "score",
           "range": true,
           "refId": "A"
@@ -354,7 +354,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(\n        (   \n                sum(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",le=\"180\",code=~\"^2..$\"})\n                + (\n                        sum(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",le=\"360\",code=~\"^2..$\"})\n                        - sum(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",le=\"180\",code=~\"^2..$\"})\n                ) / 2\n        ) / sum(cht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",code=~\"^2..$\"})\n) * 100",
+          "expr": "(\n        (   \n                sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$\"}[$__range]))\n                + (\n                        sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"360\",code=~\"^2..$\"}[$__range]))\n                        - sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$\"}[$__range]))\n                ) / 2\n        ) / sum(delta(cht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\"}[$__range]))\n) * 100",
           "legendFormat": "score",
           "range": true,
           "refId": "A"
@@ -646,6 +646,6 @@
   "timezone": "",
   "title": "CHT Replication",
   "uid": "d4f05050-804e-4ea4-9642-4d088cc39a1b",
-  "version": 5,
+  "version": 6,
   "weekStart": ""
 }


### PR DESCRIPTION
#90 

Fixes quit a few bugs in ApDex:

1. Contrains calcs to selected period instead of calculating for all-time
2. ApDex graph should apply to replication routes only
3. One ApDex graph used buckets 90/180 for the thresholds, the other used buckets 180/360. Consolidate on latter.
4. Colour formatting for ApDex < 98 instead of <90
5. Error rate should include ELB timeouts (1 hour)

After changes:
![image](https://github.com/medic/cht-watchdog/assets/9014751/6e456fb2-302c-447f-b70e-7389a7cc5d50)
