### PR TITLE
chore: ignore eslint and chai in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,6 @@ updates:
       commitlint:
         patterns:
           - "@commitlint/*"
+    ignore:
+      - dependency-name: "chai" # ESM Modules
+      - dependency-name: "eslint" # ESM Modules

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,5 +19,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: npm ci
+      - run: npm run lint
       - name: Run test suite
         run: npm run test-integration


### PR DESCRIPTION
Updating these dependencies is blocked because of the ESM module requirement.

[Dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#example-disabling-version-updates-for-some-dependencies).

This PR also adds linting to our CI run.  This would have failed the dependabot eslint PR if we were actually running linting. 