### PR TITLE
chore: update link to docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A monitoring and alerting stack for the CHT built on [Prometheus](https://promet
 
 ## Using
 
-See our [docs site](https://docs.communityhealthtoolkit.org/apps/guides/hosting/monitoring/setup/)!
+See our [docs site](https://docs.communityhealthtoolkit.org/hosting/monitoring/setup/)!
 
 ## Development and Releasing
 


### PR DESCRIPTION
Additionally, [added the missing alias](https://github.com/medic/cht-docs/pull/1684) on the docs site to ensure the old link is not sending `404`s.