### PR TITLE
fix(#128): make express metrics always http

### DIFF
--- a/prometheus/config/prometheus.yml
+++ b/prometheus/config/prometheus.yml
@@ -11,6 +11,7 @@ scrape_configs:
       - targets: ['grafana:3000']
   - job_name: cht-express-metrics
     metrics_path: /api/v1/express-metrics
+    scheme: "https"
     file_sd_configs:
       - files:
         - '/etc/prometheus/cht-instances.yml'


### PR DESCRIPTION
this PR adds `scheme: "https"` to the [express metrics scrape config](https://github.com/medic/cht-watchdog/blob/62a7be1e39d9513ed9a174b8d641b3282344a5f5/prometheus/config/prometheus.yml#L12)

see  #128  for some logic around this choice