### PR TITLE
fix(#154): fix for apdex calculations

### DIFF
--- a/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
+++ b/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
@@ -41,7 +41,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "The target is a score of 100 means the average user is satisfied (sync under 3 min).  The more users that are tolerating sync (3min to 6min sync) or frustrated (greater than 6min sync), the lower the score is.  See the <a href='https://en.wikipedia.org/wiki/Apdex'>Apdex Wikipedia article</a> for more details.",
+      "description": "A score of 100 means all sync time at the server are fast enough to satisfy user's expectations (sync is faster than 3 minutes).  As performance takes longer than 3 minutes, users begin to be less satisfied and this ApDex number reduces. Users tolerate syncs which take between 3mins and 6mins, they are frustrated by sync times over 6mins.  See the <a href='https://en.wikipedia.org/wiki/Apdex'>Apdex Wikipedia article</a> for more details.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
+++ b/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
@@ -41,7 +41,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Target replication performance under 3min.\nTolerated replication performance under 6min.",
+      "description": "The target is a score of 100 means the average user is satisfied (sync under 3 min).  The more users that are tolerating sync (3min to 6min sync) or frustrated (greater than 6min sync), the lower the score is.  See the <a href='https://en.wikipedia.org/wiki/Apdex'>Apdex Wikipedia article</a> for more details.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
+++ b/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
@@ -110,7 +110,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(\n        (   \n                sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$\"}[$__range]))\n                + (\n                        sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"360\",code=~\"^2..$\"}[$__range]))\n                        - sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$\"}[$__range]))\n                ) / 2\n        ) / sum(delta(cht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\"}[$__range]))\n) * 100",
+          "expr": "(\n        (   \n                sum(increase(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$|^3..$\"}[$__range]))\n                + (\n                        sum(increase(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"360\",code=~\"^2..$|^3..$\"}[$__range]))\n                        - sum(increase(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$|^3..$\"}[$__range]))\n                ) / 2\n        ) / sum(increase(cht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\",code=~\"^2..$|^3..$\"}[$__range]))\n) * 100",
           "legendFormat": "score",
           "range": true,
           "refId": "A"
@@ -288,7 +288,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(\n\t(\n\t\tsum(\n\t\t\tcht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\",code=~\"^[45]..$\"} OR on() vector(0)\n\t\t)\n\t\t+ sum(\n\t\t\tcht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",ge=\"3600\",code=~\"^2..$\"} OR on() vector(0)\n\t\t)\n\t) / \n\tsum(\n\t\tcht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\"}\n\t)\n)*100",
+          "expr": "(\n\t(\n\t\tsum(\n\t\t\tcht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\",code=~\"^[45]..$\"} OR on() vector(0)\n\t\t)\n\t\t+ sum(\n\t\t\tcht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",ge=\"3600\",code=~\"^2..$|^3..$\"} OR on() vector(0)\n\t\t)\n\t) / \n\tsum(\n\t\tcht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\"}\n\t)\n)*100",
           "legendFormat": "error %",
           "range": true,
           "refId": "A"
@@ -354,7 +354,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(\n        (   \n                sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$\"}[$__range]))\n                + (\n                        sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"360\",code=~\"^2..$\"}[$__range]))\n                        - sum(delta(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$\"}[$__range]))\n                ) / 2\n        ) / sum(delta(cht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\"}[$__range]))\n) * 100",
+          "expr": "(\n        (   \n                sum(increase(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$|^3..$\"}[$__range]))\n                + (\n                        sum(increase(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"360\",code=~\"^2..$|^3..$\"}[$__range]))\n                        - sum(increase(cht_api_http_request_duration_seconds_bucket{instance=~\"$cht_instance\",route=~\".*/get-ids\",le=\"180\",code=~\"^2..$|^3..$\"}[$__range]))\n                ) / 2\n        ) / sum(increase(cht_api_http_request_duration_seconds_count{instance=~\"$cht_instance\",route=~\".*/get-ids\",code=~\"^2..$|^3..$\"}[$__range]))\n) * 100",
           "legendFormat": "score",
           "range": true,
           "refId": "A"
@@ -646,6 +646,6 @@
   "timezone": "",
   "title": "CHT Replication",
   "uid": "d4f05050-804e-4ea4-9642-4d088cc39a1b",
-  "version": 6,
+  "version": 7,
   "weekStart": ""
 }

--- a/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
+++ b/grafana/provisioning/dashboards/CHT/cht_partnerships_replication.json
@@ -41,7 +41,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "A score of 100 means all sync time at the server are fast enough to satisfy user's expectations (sync is faster than 3 minutes).  As performance takes longer than 3 minutes, users begin to be less satisfied and this ApDex number reduces. Users tolerate syncs which take between 3mins and 6mins, they are frustrated by sync times over 6mins.  See the <a href='https://en.wikipedia.org/wiki/Apdex'>Apdex Wikipedia article</a> for more details.",
+      "description": "A score of 100 means all successful syncs proceeded by the server are fast enough to satisfy user's expectations (the sync completes in less than 3 mins).  When the server takes longer than 3 minutes, users begin to be less satisfied and this ApDex number reduces. Users tolerate syncs which take between 3mins and 6mins. Users are frustrated by sync times over 6mins.  See the <a href='https://en.wikipedia.org/wiki/Apdex'>Apdex Wikipedia article</a> for more details.",
       "fieldConfig": {
         "defaults": {
           "color": {


### PR DESCRIPTION
fixes #154

Also taking a moment to update apdex tooltip helptext from:

> Target replication performance under 3min. Tolerated replication performance under 6min.

to instead be:

> The target is a score of 100 means the average user is satisfied (sync under 3 min).  The more users that are tolerating sync (3min to 6min sync) or frustrated (greater than 6min sync), the lower the score is.  See the [Apdex Wikipedia article](https://en.wikipedia.org/wiki/Apdex) for more details.

As shown here:

![image](https://github.com/user-attachments/assets/bbb16d4a-69e2-4e23-8f78-0ee584b9d4e7)
