### PR TITLE
feat(#136): add new metrics of CouchDB Nouveau to JSON exporter

### DIFF
--- a/exporters/json/config/cht.yml
+++ b/exporters/json/config/cht.yml
@@ -29,7 +29,11 @@ x-cht_messaging_outgoing_total: &cht_messaging_outgoing_total
   valuetype: counter
 x-cht_couchdb_view_index_size_bytes: &cht_couchdb_view_index_size_bytes
   name: cht_couchdb_view_index_size_bytes
-  help: The size in bytes the view.
+  help: The size in bytes of CouchDB views.
+  valuetype: gauge
+x-cht_couchdb_nouveau_index_size_bytes: &cht_couchdb_nouveau_index_size_bytes
+  name: cht_couchdb_nouveau_index_size_bytes
+  help: The size in bytes of CouchDB Nouveau views.
   valuetype: gauge
 
 modules:
@@ -272,6 +276,19 @@ modules:
         labels:
           db: '_users'
           view_index: 'users'
+          type: 'file'
+
+      - <<: *cht_couchdb_nouveau_index_size_bytes
+        path: '{.couchdb.medic.nouveau_indexes[?(@.name=="medic/contacts_by_freetext")].file_size}'
+        labels:
+          db: 'medic'
+          nouveau_index: 'contacts_by_freetext'
+          type: 'file'
+      - <<: *cht_couchdb_nouveau_index_size_bytes
+        path: '{.couchdb.medic.nouveau_indexes[?(@.name=="medic/reports_by_freetext")].file_size}'
+        labels:
+          db: 'medic'
+          nouveau_index: 'reports_by_freetext'
           type: 'file'
 
       - name: cht_date_current_millis


### PR DESCRIPTION
Adds new metrics from the monitoring API to JSON exporter.

Closes: #136 

Sample response from `/api/v2/monitoring` endpoint that includes the CouchDB Nouveau metric.

```json
{
    "version": {
        "app": "4.20.0-local-development",
        "node": "v22.15.0",
        "couchdb": "3.5.0"
    },
    "couchdb": {
        "medic": {
            "name": "medic",
            "update_sequence": 26322,
            "doc_count": 25187,
            "doc_del_count": 6,
            "fragmentation": 1.1366011919431802,
            "sizes": {
                "active": 24376884,
                "file": 24771200
            },
            "view_indexes": [
                {
                    "name": "medic",
                    "sizes": {
                        "active": 19676961,
                        "file": 23455553
                    }
                },
                {
                    "name": "medic-admin",
                    "sizes": {
                        "active": 0,
                        "file": 2266924
                    }
                },
                {
                    "name": "medic-client",
                    "sizes": {
                        "active": 31492481,
                        "file": 36945293
                    }
                },
                {
                    "name": "medic-conflicts",
                    "sizes": {
                        "active": 0,
                        "file": 2274828
                    }
                },
                {
                    "name": "medic-scripts",
                    "sizes": {
                        "active": 34510598,
                        "file": 39918785
                    }
                },
                {
                    "name": "medic-sms",
                    "sizes": {
                        "active": 0,
                        "file": 2271596
                    }
                }
            ],
            "nouveau_indexes": [
                {
                    "name": "medic/contacts_by_freetext",
                    "doc_count": 4772,
                    "file_size": 1805017
                },
                {
                    "name": "medic/reports_by_freetext",
                    "doc_count": 20250,
                    "file_size": 6211706
                }
            ]
        },
        "sentinel": {
            "name": "medic-sentinel",
            "update_sequence": 879,
            "doc_count": 840,
            "doc_del_count": 1,
            "fragmentation": 1.6597705100071385,
            "sizes": {
                "active": 302584,
                "file": 502220
            },
            "view_indexes": [
                {
                    "name": "sentinel",
                    "sizes": {
                        "active": 0,
                        "file": 234984
                    }
                }
            ],
            "nouveau_indexes": []
        },
        "usersmeta": {
            "name": "medic-users-meta",
            "update_sequence": 1275,
            "doc_count": 1249,
            "doc_del_count": 1,
            "fragmentation": 1.0740754277706823,
            "sizes": {
                "active": 6816072,
                "file": 7027148
            },
            "view_indexes": [
                {
                    "name": "users-meta",
                    "sizes": {
                        "active": 434308,
                        "file": 760307
                    }
                }
            ],
            "nouveau_indexes": []
        },
        "users": {
            "name": "_users",
            "update_sequence": 158,
            "doc_count": 127,
            "doc_del_count": 1,
            "fragmentation": 4.23068510512168,
            "sizes": {
                "active": 82195,
                "file": 293360
            },
            "view_indexes": [
                {
                    "name": "users",
                    "sizes": {
                        "active": 15644,
                        "file": 120566
                    }
                }
            ],
            "nouveau_indexes": []
        }
    },
    "date": {
        "current": 1750155802202,
        "uptime": 395.497196272
    },
    "sentinel": {
        "backlog": 25193
    },
    "messaging": {
        "outgoing": {
            "total": {
                "due": 0,
                "scheduled": 0,
                "muted": 0,
                "failed": 0,
                "delivered": 0
            },
            "seven_days": {
                "due": 0,
                "scheduled": 0,
                "muted": 0,
                "failed": 0,
                "delivered": 0
            },
            "last_hundred": {
                "pending": {
                    "pending": 0,
                    "forwarded-to-gateway": 0,
                    "received-by-gateway": 0,
                    "forwarded-by-gateway": 0
                },
                "final": {
                    "sent": 0,
                    "delivered": 0,
                    "failed": 0
                },
                "muted": {
                    "denied": 0,
                    "cleared": 0,
                    "muted": 0,
                    "duplicate": 0
                }
            }
        }
    },
    "outbound_push": {
        "backlog": 0
    },
    "feedback": {
        "count": 0
    },
    "conflict": {
        "count": 0
    },
    "replication_limit": {
        "count": 0
    },
    "connected_users": {
        "count": 1
    }
}
```