### PR TITLE
fix(#159) exclude negative numbers from results

### DIFF
--- a/grafana/provisioning/dashboards/CHT/cht_admin_details.json
+++ b/grafana/provisioning/dashboards/CHT/cht_admin_details.json
@@ -137,7 +137,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "cht_couchdb_doc_total{db=\"$db_name\", instance=~\"$cht_instance\"}",
+          "expr": "cht_couchdb_doc_total{db=\"$db_name\", instance=~\"$cht_instance\"} >= 0",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -235,7 +235,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "cht_conflict_count{instance=~\"$cht_instance\"}",
+          "expr": "cht_conflict_count{instance=~\"$cht_instance\"} >= 0",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -363,7 +363,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "builder",
-          "expr": "cht_couchdb_doc_del_total{instance=~\"$cht_instance\"}",
+          "expr": "cht_couchdb_doc_del_total{instance=~\"$cht_instance\"} >= 0",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -665,7 +665,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "cht_couchdb_fragmentation{instance=~\"$cht_instance\"}",
+          "expr": "cht_couchdb_fragmentation{instance=~\"$cht_instance\"} >= 0",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -752,7 +752,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "cht_date_current_millis{instance=~\"$cht_instance\"}",
+              "expr": "cht_date_current_millis{instance=~\"$cht_instance\"} >= 0",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -845,7 +845,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "builder",
-              "expr": "cht_sentinel_backlog_count{instance=~\"$cht_instance\"}",
+              "expr": "cht_sentinel_backlog_count{instance=~\"$cht_instance\"} >= 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "backlog"
@@ -968,7 +968,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "builder",
-              "expr": "cht_replication_limit_count{instance=~\"$cht_instance\"}",
+              "expr": "cht_replication_limit_count{instance=~\"$cht_instance\"} >= 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "users_over_limit"
@@ -1093,7 +1093,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "builder",
-              "expr": "cht_feedback_total{instance=~\"$cht_instance\"}",
+              "expr": "cht_feedback_total{instance=~\"$cht_instance\"} >= 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -1193,7 +1193,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "builder",
-              "expr": "cht_outbound_push_backlog_count{instance=~\"$cht_instance\"}",
+              "expr": "cht_outbound_push_backlog_count{instance=~\"$cht_instance\"} >= 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -1319,7 +1319,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "builder",
-              "expr": "cht_connected_users_count{instance=~\"$cht_instance\"}",
+              "expr": "cht_connected_users_count{instance=~\"$cht_instance\"} >= 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -1430,7 +1430,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "builder",
-              "expr": "sum(cht_messaging_outgoing_total{instance=~\"$cht_instance\"})",
+              "expr": "sum(cht_messaging_outgoing_total{instance=~\"$cht_instance\"}) >= 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -1527,7 +1527,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "builder",
-              "expr": "cht_messaging_outgoing_total{instance=~\"$cht_instance\", status=\"due\"}",
+              "expr": "cht_messaging_outgoing_total{instance=~\"$cht_instance\", status=\"due\"} >= 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -1624,7 +1624,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "builder",
-              "expr": "cht_messaging_outgoing_total{instance=~\"$cht_instance\", status=\"delivered\"}",
+              "expr": "cht_messaging_outgoing_total{instance=~\"$cht_instance\", status=\"delivered\"} >= 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -1721,7 +1721,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "builder",
-              "expr": "cht_messaging_outgoing_total{instance=~\"$cht_instance\", status=\"muted\"}",
+              "expr": "cht_messaging_outgoing_total{instance=~\"$cht_instance\", status=\"muted\"} >= 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -1818,7 +1818,7 @@
                 "uid": "PBFA97CFB590B2093"
               },
               "editorMode": "builder",
-              "expr": "cht_messaging_outgoing_total{instance=~\"$cht_instance\", status=\"failed\"}",
+              "expr": "cht_messaging_outgoing_total{instance=~\"$cht_instance\", status=\"failed\"} >= 0",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -1912,7 +1912,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"pending\"})",
+              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"pending\"} >= 0)",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -1925,7 +1925,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"muted\"})",
+              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"muted\"} >= 0)",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
@@ -1939,7 +1939,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"final\"})",
+              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"final\"} >= 0)",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
@@ -2018,7 +2018,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"pending\"}",
+              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"pending\"} >= 0",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -2096,7 +2096,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"muted\"}",
+              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"muted\"} >= 0",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -2174,7 +2174,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"final\"}",
+              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"final\"} >= 0",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -2245,7 +2245,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"pending\"}",
+              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"pending\"} >= 0",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -2315,7 +2315,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"muted\"}",
+              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"muted\"} >= 0",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -2385,7 +2385,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"final\"}",
+              "expr": "cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"final\"} >= 0",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -2457,7 +2457,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"pending\"})",
+              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"pending\"} >= 0)",
               "instant": true,
               "legendFormat": "__auto",
               "range": false,
@@ -2470,7 +2470,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"muted\"})",
+              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"muted\"} >= 0)",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
@@ -2484,7 +2484,7 @@
               },
               "editorMode": "builder",
               "exemplar": false,
-              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"final\"})",
+              "expr": "sum(cht_messaging_outgoing_last_hundred{instance=~\"$cht_instance\", group=\"final\"} >= 0)",
               "hide": false,
               "instant": true,
               "legendFormat": "__auto",
@@ -2567,7 +2567,7 @@
         "name": "db_name",
         "options": [],
         "query": {
-          "query": "cht_couchdb_doc_total{instance=~\"$cht_instance\"}",
+          "query": "cht_couchdb_doc_total{instance=~\"$cht_instance\"} >= 0",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
@@ -2586,6 +2586,6 @@
   "timezone": "",
   "title": "CHT Admin Details",
   "uid": "hkQUbyfVk",
-  "version": 43,
+  "version": 44,
   "weekStart": ""
 }


### PR DESCRIPTION
This PR adds `>= 0` to key queries to prevent negative values from being shown in CHT Core graphs.

closes #159